### PR TITLE
Handle expired cookies, cleanup and TTL

### DIFF
--- a/backend/cookie_manager.py
+++ b/backend/cookie_manager.py
@@ -93,10 +93,6 @@ class RedisCookieManager:
             return
 
         key = self._key(auth_id)
-        if self.cache.get(key) == content:
-            if cleanup:
-                self._remove_local(path)
-            return
 
         try:
             self.redis.set(key, content, ex=self.ttl_seconds)

--- a/backend/main.py
+++ b/backend/main.py
@@ -143,6 +143,7 @@ async def create_scraper(auth_id: str, password: str) -> TwitterScraper:
     """Initialize scraper with credentials and authenticate."""
     cookie_manager = RedisCookieManager()
     cookie_path = cookie_manager.load_cookie(auth_id)
+    first_login = not cookie_path.exists()
     credentials = TwitterCredentials(
         auth_id=auth_id,
         password=password,
@@ -150,7 +151,7 @@ async def create_scraper(auth_id: str, password: str) -> TwitterScraper:
     )
     config = TwitterConfig(credentials=credentials, output_dir="output")
     scraper = TwitterScraper(config, cookie_manager=cookie_manager)
-    await scraper.authenticate()
+    await scraper.authenticate(cleanup_cookie=first_login)
     return scraper
 
 @app.post("/X/timeline")


### PR DESCRIPTION
## Summary
- add TTL, cleanup, and delete helpers to RedisCookieManager
- refresh cookie on failed login and allow cleanup
- clean up new cookie files created on first login

## Testing
- `python3 -m py_compile backend/*.py backend/scraper/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68761c4749088321b88a906a2ede886f