### PR TITLE
Add web-based verification for Twitter login

### DIFF
--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -75,6 +75,7 @@ export interface TwitterSearchParams {
   mode: string;
   start_date?: string | null;
   end_date?: string | null;
+  verification_responses?: string[];
 }
 
 export interface ApiResponse<T> {


### PR DESCRIPTION
## Summary
- handle verification prompts in TwitterScraper by intercepting `input()` calls
- surface verification requirement via API with 401 status and prompt text
- extend request models and scraper creation to pass verification responses
- update frontend to loop through verification prompts
- add optional `verification_responses` to shared types

## Testing
- `python -m py_compile backend/main.py backend/scraper/X.py`

------
https://chatgpt.com/codex/tasks/task_e_6876b96345b48321bbe3e0ca268e5f5f